### PR TITLE
Fix the wrong stack name

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -118,4 +118,4 @@ const env = {
   account: app.node.tryGetContext('account') || process.env.CDK_DEPLOY_ACCOUNT || process.env.CDK_DEFAULT_ACCOUNT
 };
 
-const ProxySQLStack = new ProxysqlFargate(app, 'ProxySQL2', { env })
+const ProxySQLStack = new ProxysqlFargate(app, 'ProxySQL', { env })


### PR DESCRIPTION
*Issue #, if available:*
#1 

*Description of changes:*
Fix the stack name to ProxySQL, following the one in README.md 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
